### PR TITLE
fix terraform.sh

### DIFF
--- a/azure/terraform.sh
+++ b/azure/terraform.sh
@@ -67,7 +67,7 @@ function list_env() {
 
 function other_actions() {
   if [ -n "$env" ] && [ -n "$action" ]; then
-    terraform "$action" -var-file="./env/$env/terraform.tfvars" -compact-warnings ${other:+"$other"}
+    terraform "$action" -var-file="./env/$env/terraform.tfvars" -compact-warnings $other
   else
     echo "ERROR: no env or action configured!"
     exit 1
@@ -75,7 +75,7 @@ function other_actions() {
 }
 
 function state_output_taint_actions() {
-  terraform "$action" "$other"
+  terraform $action $other
 }
 
 function tfsummary() {
@@ -175,7 +175,7 @@ case $action in
     ;;
   output|state|taint)
     init_terraform
-    state_output_taint_actions "$other"
+    state_output_taint_actions $other
     ;;
   summ)
     init_terraform
@@ -185,7 +185,6 @@ case $action in
     update_script
     ;;
   *)
-    init_terraform
     other_actions "$other"
     ;;
 esac

--- a/azure/terraform.sh
+++ b/azure/terraform.sh
@@ -185,6 +185,7 @@ case $action in
     update_script
     ;;
   *)
+    [ -z "$TF_INIT" ] && terraform init
     other_actions "$other"
     ;;
 esac


### PR DESCRIPTION
- fix terraform.sh (bug introduced in the previous version)
- remove `terraform init` from `plan` and `apply`

aggiunto:
`[ -z "$TF_INIT" ] && terraform init`
che significa che se la variabile ambiente TF_INIT NON e' definita il terraform init viene sempre eseguito.
Qualsiasi valore per la variabile ambiente TF_INIT fa si che terraform init non venga eseguito per plan e apply (viene comunque eseguito per gli altri comandi)