### PR TITLE
feat: Add -tfplan argument

### DIFF
--- a/azure/terraform.sh
+++ b/azure/terraform.sh
@@ -82,37 +82,35 @@ function state_output_taint_actions() {
   terraform $action $other
 }
 
-function parse_tfplan_option() {
-  # Loop over all arguments
+function parse_and_remove_tfplan_option() {
+  # Creare array per contenere gli argomenti che non iniziano con '-tfplan='
+  local other_args=()
+
+  # Ciclo su tutti gli argomenti
   for arg in "$@"; do
-    # If the argument starts with '-tfplan=', extract the filename
+    # Se l'argomento inizia con '-tfplan=', estrai il nome del file
     if [[ "$arg" =~ ^-tfplan= ]]; then
       echo "${arg#*=}"
-      return
+    else
+      # Se l'argomento non inizia con '-tfplan=', aggiungilo all'array other_args
+      other_args+=("$arg")
     fi
   done
-}
 
-function remove_tfplan_option() {
-  # Loop over all arguments
-  for arg in "$@"; do
-    # If the argument starts with '-tfplan=', skip it
-    if [[ ! "$arg" =~ ^-tfplan= ]]; then
-      echo "$arg"
-    fi
-  done
+  # Stampa tutti gli argomenti in other_args separati da spazi
+  echo "${other_args[@]}"
 }
 
 function tfsummary() {
   local plan_file
-  plan_file=$(parse_tfplan_option "$@")
+  plan_file=$(parse_and_remove_tfplan_option "$@")
   action="plan"
   other="-out=${plan_file}"
-  other_actions $(remove_tfplan_option "$@")
+  other_actions $(parse_and_remove_tfplan_option "$@")
   if [ -n "$(command -v tf-summarize)" ]; then
     tf-summarize ${tree} "${plan_file}"
   else
-    echo "tf-summarize is not installed"
+    echo "tf-summarize non è installato"
   fi
 }
 

--- a/azure/terraform.sh
+++ b/azure/terraform.sh
@@ -5,7 +5,7 @@
 ############################################################
 # Global variables
 # Version format x.y accepted
-vers="1.4"
+vers="1.5"
 script_name=$(basename "$0")
 git_repo="https://raw.githubusercontent.com/pagopa/eng-common-scripts/main/azure/${script_name}"
 tmp_file="${script_name}.new"
@@ -29,7 +29,8 @@ function help_usage() {
   echo "  help          This help"
   echo "  list          List every environment available"
   echo "  update        Update this script if possible"
-  echo "  summ          Generate summary of Terraform plan"
+  echo "  summ          Generate a summary of Terraform plan"
+  echo "  summtable     Generate a summary table of Terraform plan"
   echo "  *             any terraform option"
 }
 
@@ -84,10 +85,11 @@ function tfsummary() {
   other="-out=tfplan"
   other_actions
   if [ -n "$(command -v tf-summarize)" ]; then
-    tf-summarize -separate-tree tfplan && rm tfplan
+    tf-summarize ${tree} tfplan
   else
     echo "tf-summarize is not installed"
   fi
+  rm tfplan 2>/dev/null
 }
 
 function update_script() {
@@ -164,11 +166,10 @@ case $action in
   clean)
     clean_environment
     ;;
-  ?|help)
+  ?|help|-h)
     help_usage
     ;;
   init)
-    init_terraform
     init_terraform "$other"
     ;;
   list)
@@ -179,6 +180,12 @@ case $action in
     state_output_taint_actions $other
     ;;
   summ)
+    init_terraform
+    tree="-separate-tree"
+    tfsummary "$other"
+    unset tree
+    ;;
+  summtable)
     init_terraform
     tfsummary "$other"
     ;;

--- a/azure/terraform.sh
+++ b/azure/terraform.sh
@@ -80,21 +80,21 @@ function state_output_taint_actions() {
 }
 
 function parse_tfplan_option() {
-  # Creare array per contenere gli argomenti che non iniziano con '-tfplan='
+  # Create an array to contain arguments that do not start with '-tfplan='
   local other_args=()
 
-  # Ciclo su tutti gli argomenti
+  # Loop over all arguments
   for arg in "$@"; do
-    # Se l'argomento inizia con '-tfplan=', estrai il nome del file
+    # If the argument starts with '-tfplan=', extract the file name
     if [[ "$arg" =~ ^-tfplan= ]]; then
       echo "${arg#*=}"
     else
-      # Se l'argomento non inizia con '-tfplan=', aggiungilo all'array other_args
+      # If the argument does not start with '-tfplan=', add it to the other_args array
       other_args+=("$arg")
     fi
   done
 
-  # Stampa tutti gli argomenti in other_args separati da spazi
+  # Print all arguments in other_args separated by spaces
   echo "${other_args[@]}"
 }
 


### PR DESCRIPTION
The script modification introduces the **-tfplan** option to the terraform plan command, which allows users to specify an output file for the execution plan. If this option is not provided, the script will default to outputting the execution plan to a file named "**tfplan**". This functionality is encapsulated in the **tfsummary** function.